### PR TITLE
Adding message models

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,6 @@
+class Message
+  include Mongoid::Document
+
+  field :message_id, :default => proc { "fail-#{Time.now.to_f.to_s}" }
+  has_many :message_reports, primary_key: :message_id, foreign_key: :message_id
+end

--- a/app/models/message_report.rb
+++ b/app/models/message_report.rb
@@ -1,0 +1,9 @@
+class MessageReport
+  include Mongoid::Document
+
+
+  field :message_id, :default => proc { "fail-#{Time.now.to_f.to_s}" }
+
+  belongs_to :message, primary_key: :message_id, foreign_key: :message_id
+
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require "spec_helper"
+
+describe Message do
+
+  describe "#create" do
+
+    let(:message) do
+      Message.create!
+    end
+
+    let(:report) do
+      message.message_reports.create!
+    end
+
+    it "has fk on report same as pk on message" do
+      report.message_id.should eq(message.message_id)
+    end
+
+    it "does not use _id on message fk" do
+      report.message_id.should_not eq(message.id)
+    end
+  end
+
+  describe "reloading from db" do
+
+    let(:message) do
+      Message.create!
+    end
+
+    let!(:report) do
+      message.message_reports.create!
+    end
+
+    let(:from_db) do
+      Message.find(message.id)
+    end
+
+    it "has all reports" do
+      from_db.message_reports.should eq([report])
+    end
+  end
+end


### PR DESCRIPTION
Adding `Message`, `MessageReport` models to echo. So we are able to test relation with different primary_key.
This models will work on with mongoid 3.1+.

Feature request: https://github.com/mongoid/mongoid/issues/1850
